### PR TITLE
Refactor children-finding methods to return nil

### DIFF
--- a/lib/nanoc-conref-fs/ancestry.rb
+++ b/lib/nanoc-conref-fs/ancestry.rb
@@ -62,36 +62,34 @@ module NanocConrefFS
     # Given a category file that's an array, this method finds
     # the children of an item, probably a map topic
     def find_array_children(toc, title)
-      children = ''
       toc.each do |item|
         next unless item.is_a?(Hash)
         item.each_pair do |key, values|
           if key == title
             children = values.flatten
-            break
+            return children unless children.empty?
           end
         end
-        break unless children.empty?
       end
-      children
+      # Found no children
+      nil
     end
     module_function :find_array_children
 
     # Given a category file that's a hash, this method finds
     # the children of an item, probably a map topic
     def find_hash_children(toc, title)
-      children = ''
       toc.each_key do |key|
         toc[key].each do |item|
           next unless item.is_a?(Hash)
-          unless item[title].nil?
+          if item[title]
             children = item.values.flatten
-            break
+            return children unless children.empty?
           end
         end
-        break unless children.empty?
       end
-      children
+      # Found no children
+      nil
     end
     module_function :find_hash_children
   end

--- a/lib/nanoc-conref-fs/ancestry.rb
+++ b/lib/nanoc-conref-fs/ancestry.rb
@@ -61,6 +61,11 @@ module NanocConrefFS
 
     # Given a category file that's an array, this method finds
     # the children of an item, probably a map topic
+    #
+    # toc - the array containing the table of contents
+    # title - the text title to return the children of
+    #
+    # Returns a flattened array of all descendants or nil.
     def find_array_children(toc, title)
       toc.each do |item|
         next unless item.is_a?(Hash)
@@ -78,6 +83,11 @@ module NanocConrefFS
 
     # Given a category file that's a hash, this method finds
     # the children of an item, probably a map topic
+    #
+    # toc - the hash containing the table of contents
+    # title - the text title to return the children of
+    #
+    # Returns a flattened array of all descendants or nil.
     def find_hash_children(toc, title)
       toc.each_key do |key|
         toc[key].each do |item|

--- a/lib/nanoc-conref-fs/ancestry.rb
+++ b/lib/nanoc-conref-fs/ancestry.rb
@@ -65,19 +65,19 @@ module NanocConrefFS
     # toc - the array containing the table of contents
     # title - the text title to return the children of
     #
-    # Returns a flattened array of all descendants or nil.
+    # Returns a flattened array of all descendants which could be empty.
     def find_array_children(toc, title)
       toc.each do |item|
         next unless item.is_a?(Hash)
         item.each_pair do |key, values|
           if key == title
             children = values.flatten
-            return children unless children.empty?
+            return children
           end
         end
       end
       # Found no children
-      nil
+      Array.new
     end
     module_function :find_array_children
 
@@ -87,19 +87,19 @@ module NanocConrefFS
     # toc - the hash containing the table of contents
     # title - the text title to return the children of
     #
-    # Returns a flattened array of all descendants or nil.
+    # Returns a flattened array of all descendants which could be empty.
     def find_hash_children(toc, title)
       toc.each_key do |key|
         toc[key].each do |item|
           next unless item.is_a?(Hash)
           if item[title]
             children = item.values.flatten
-            return children unless children.empty?
+            return children
           end
         end
       end
       # Found no children
-      nil
+      Array.new
     end
     module_function :find_hash_children
   end

--- a/nanoc-conref-fs.gemspec
+++ b/nanoc-conref-fs.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test)/})
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'nanoc', '~> 4.0'
+  spec.add_runtime_dependency 'nanoc', '>= 4.0', '< 4.2'
   spec.add_runtime_dependency 'activesupport', '~> 4.2'
   spec.add_runtime_dependency 'liquid', '~> 3.0'
 

--- a/test/ancestry_test.rb
+++ b/test/ancestry_test.rb
@@ -49,6 +49,18 @@ class AncestryTest < MiniTest::Test
     end
   end
 
+  def test_it_renders_content_with_no_children
+    with_site(name: FIXTURES_DIR) do |site|
+
+      site = Nanoc::Int::SiteLoader.new.new_from_cwd
+      site.compile
+
+      output_file = read_output_file('children', 'no_children')
+      test_file = read_test_file('children', 'no_children')
+      assert_equal output_file, test_file
+    end
+  end
+
   def test_it_renders_hash_children
     with_site(name: FIXTURES_DIR) do |site|
 

--- a/test/fixtures/content/children/no_children.html
+++ b/test/fixtures/content/children/no_children.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>
+  No children
+  </title>
+</head>
+
+<body>
+
+  
+Below should be an empty array.
+
+
+  []
+
+</body>
+</html>

--- a/test/fixtures/content/children/no_children.md
+++ b/test/fixtures/content/children/no_children.md
@@ -1,0 +1,5 @@
+---
+title: No children
+---
+
+Below should be an empty array.

--- a/test/fixtures/data/categories/category.yml
+++ b/test/fixtures/data/categories/category.yml
@@ -7,6 +7,7 @@ Collaborating:
     - Setting the default branch
     - Viewing branches in your repository
     - Creating and deleting branches within your repository
+  - No children
 
   - Some other things:
     - Blah1


### PR DESCRIPTION
Using an early return instead of a result variable gets rid of two breaks at different nesting levels.

 I'm not actually sure if the guard against returning an empty list of children should be preserved or if we should return nil immediately. It depends on whether we want to allow for an item to be present multiple
times in the TOC. But if it is only the first found entry with children will be used so the behavior is still ill-defined.

Even without the instant return in the case that an item isn't found or has [no children][1], this does change behavior to always return nil.

/cc @gjtorikian @lachlanhardy @lynnwallenstein

[1]: https://www.youtube.com/watch?v=wRP6egIEABk