### PR TITLE
issue with reading non-ascii characters in yaml document

### DIFF
--- a/lib/nanoc-conref-fs/datafiles.rb
+++ b/lib/nanoc-conref-fs/datafiles.rb
@@ -45,7 +45,7 @@ module NanocConrefFS
     def self.collect_data(dir)
       data_files = {}
       Dir["#{dir}/**/*.{yaml,yml}"].each do |filename|
-        data_files[filename] = File.read(filename)
+        data_files[filename] = File.read(filename, encoding: 'UTF-8')
       end
       data_files
     end


### PR DESCRIPTION
Parsing yaml documents with non-ascii characters lead to wrong characters. adding utf-8 forced encoding fixes this, as UTF-8 should be standard through all yaml documents