### PR TITLE
Check for nil before calling #each in ancestry.

### DIFF
--- a/lib/nanoc-conref-fs/ancestry.rb
+++ b/lib/nanoc-conref-fs/ancestry.rb
@@ -37,6 +37,7 @@ module NanocConrefFS
     def find_hash_parents(toc, title)
       parents = ''
       toc.each_key do |key|
+        next if toc[key].nil?
         toc[key].each do |item|
           if item.is_a?(Hash)
             if item.keys.include?(title)
@@ -82,6 +83,7 @@ module NanocConrefFS
     def find_hash_children(toc, title)
       children = ''
       toc.each_key do |key|
+        next if toc[key].nil?
         toc[key].each do |item|
           next unless item.is_a?(Hash)
           unless item[title].nil?

--- a/test/datafiles_test.rb
+++ b/test/datafiles_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class DatafilesTest < MiniTest::Test
   def test_it_collects_the_files
     files = NanocConrefFS::Datafiles.collect_data(File.join(FIXTURES_DIR, 'data')).keys.sort
-    names = %w(categories/category categories/nested categories/simple reusables/intro reusables/names variables/asterisks variables/empty variables/product)
+    names = %w(categories/category categories/empty_category categories/nested categories/simple reusables/intro reusables/names variables/asterisks variables/empty variables/product)
     names.map! { |name| File.join(FIXTURES_DIR, 'data', "#{name}.yml") }
     assert_equal files, names
   end

--- a/test/fixtures/content/empty-categories/content-article.md
+++ b/test/fixtures/content/empty-categories/content-article.md
@@ -1,0 +1,4 @@
+---
+title: Content article
+---
+

--- a/test/fixtures/data/categories/empty_category.yml
+++ b/test/fixtures/data/categories/empty_category.yml
@@ -1,0 +1,7 @@
+Category with a thing:
+  - Content article
+
+Empty Category:
+
+Further category:
+  - Content article

--- a/test/fixtures/nanoc.yaml
+++ b/test/fixtures/nanoc.yaml
@@ -40,6 +40,13 @@ page_variables:
       version: "2.0"
   -
     scope:
+      path: "empty-categories"
+    values:
+      version: "dotcom"
+      data_association: "categories.empty_category"
+      just_a_key: wow!
+  -
+    scope:
       path: "multiple_versions"
     values:
       version: 2.2

--- a/test/variable_mixin_test.rb
+++ b/test/variable_mixin_test.rb
@@ -9,7 +9,7 @@ class VariablesTest < MiniTest::Test
       site.compile
 
       assert_equal NanocConrefFS::Variables.variables[:default].keys, ['site']
-      assert_equal NanocConrefFS::Variables.variables[:default]['site']['data'].keys, %w(categories reusables variables)
+      assert_equal NanocConrefFS::Variables.variables[:default]['site']['data'].keys.sort, %w(categories reusables variables)
     end
   end
 


### PR DESCRIPTION
With ancestry configurations loaded from YAML. An empty category will be `nil`rather than an empty array. So we need to handle that in the children and parent finding methods.

@gjtorikian I always have a terrible time setting up the fixtures for this repo. What's your suggestion on getting failures in for testing?

cc @lynnwallenstein since we paired on this among other things.