### PR TITLE
Support newer nanoc

### DIFF
--- a/nanoc-conref-fs.gemspec
+++ b/nanoc-conref-fs.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'nanoc', '~> 4.3.0'
   spec.add_runtime_dependency 'activesupport', '~> 4.2'
-  spec.add_runtime_dependency 'liquid', '4.0.0.rc2'
+  spec.add_runtime_dependency 'liquid', '3.0.6'
 
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'minitest', '~> 5.8'

--- a/nanoc-conref-fs.gemspec
+++ b/nanoc-conref-fs.gemspec
@@ -15,9 +15,9 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test)/})
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'nanoc', '>= 4.0', '< 4.2'
+  spec.add_runtime_dependency 'nanoc', '~> 4.3.0'
   spec.add_runtime_dependency 'activesupport', '~> 4.2'
-  spec.add_runtime_dependency 'liquid', '~> 3.0'
+  spec.add_runtime_dependency 'liquid', '4.0.0.rc2'
 
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'minitest', '~> 5.8'

--- a/test/ancestry_test.rb
+++ b/test/ancestry_test.rb
@@ -2,9 +2,7 @@ require 'test_helper'
 
 class AncestryTest < MiniTest::Test
   def test_it_renders_single_parents
-    with_site(name: FIXTURES_DIR) do |site|
-
-      site = Nanoc::Int::SiteLoader.new.new_from_cwd
+    with_site do |site|
       site.compile
 
       output_file = read_output_file('parents', 'single_parent')
@@ -14,9 +12,7 @@ class AncestryTest < MiniTest::Test
   end
 
   def test_it_renders_two_parents
-    with_site(name: FIXTURES_DIR) do |site|
-
-      site = Nanoc::Int::SiteLoader.new.new_from_cwd
+    with_site do |site|
       site.compile
 
       output_file = read_output_file('parents', 'two_parents')
@@ -26,9 +22,7 @@ class AncestryTest < MiniTest::Test
   end
 
   def test_it_renders_array_parents
-    with_site(name: FIXTURES_DIR) do |site|
-
-      site = Nanoc::Int::SiteLoader.new.new_from_cwd
+    with_site do |site|
       site.compile
 
       output_file = read_output_file('parents', 'array_parents')
@@ -38,9 +32,7 @@ class AncestryTest < MiniTest::Test
   end
 
   def test_missing_category_title_does_not_blow_up_parents
-    with_site(name: FIXTURES_DIR) do |site|
-
-      site = Nanoc::Int::SiteLoader.new.new_from_cwd
+    with_site do |site|
       site.compile
 
       output_file = read_output_file('parents', 'missing_title')
@@ -50,9 +42,7 @@ class AncestryTest < MiniTest::Test
   end
 
   def test_it_renders_content_with_no_children
-    with_site(name: FIXTURES_DIR) do |site|
-
-      site = Nanoc::Int::SiteLoader.new.new_from_cwd
+    with_site do |site|
       site.compile
 
       output_file = read_output_file('children', 'no_children')
@@ -62,9 +52,7 @@ class AncestryTest < MiniTest::Test
   end
 
   def test_it_renders_hash_children
-    with_site(name: FIXTURES_DIR) do |site|
-
-      site = Nanoc::Int::SiteLoader.new.new_from_cwd
+    with_site do |site|
       site.compile
 
       output_file = read_output_file('children', 'hash_children')
@@ -78,9 +66,7 @@ class AncestryTest < MiniTest::Test
   end
 
   def test_it_renders_array_children
-    with_site(name: FIXTURES_DIR) do |site|
-
-      site = Nanoc::Int::SiteLoader.new.new_from_cwd
+    with_site do |site|
       site.compile
 
       output_file = read_output_file('children', 'array_children')

--- a/test/conref_fs_test.rb
+++ b/test/conref_fs_test.rb
@@ -3,9 +3,7 @@ require 'test_helper'
 class DatafilesTest < MiniTest::Test
 
   def test_it_renders_conrefs_in_frontmatter
-    with_site(name: FIXTURES_DIR) do |site|
-
-      site = Nanoc::Int::SiteLoader.new.new_from_cwd
+    with_site do |site|
       site.compile
 
       output_file = read_output_file('frontmatter', 'title')
@@ -15,9 +13,7 @@ class DatafilesTest < MiniTest::Test
   end
 
   def test_it_renders_conrefs_in_frontmatter_at_different_path
-    with_site(name: FIXTURES_DIR) do |site|
-
-      site = Nanoc::Int::SiteLoader.new.new_from_cwd
+    with_site do |site|
       site.compile
 
       output_file = read_output_file('frontmatter', 'different')
@@ -27,9 +23,7 @@ class DatafilesTest < MiniTest::Test
   end
 
   def test_it_renders_conrefs_in_frontmatter_with_audience
-    with_site(name: FIXTURES_DIR) do |site|
-
-      site = Nanoc::Int::SiteLoader.new.new_from_cwd
+    with_site do |site|
       site.compile
 
       output_file = read_output_file('frontmatter', 'audience')
@@ -39,9 +33,7 @@ class DatafilesTest < MiniTest::Test
   end
 
   def test_it_renders_nested_conrefs
-    with_site(name: FIXTURES_DIR) do |site|
-
-      site = Nanoc::Int::SiteLoader.new.new_from_cwd
+    with_site do |site|
       site.compile
 
       output_file = read_output_file('datafiles', 'deep')
@@ -51,9 +43,7 @@ class DatafilesTest < MiniTest::Test
   end
 
   def test_it_renders_nested_conrefs
-    with_site(name: FIXTURES_DIR) do |site|
-
-      site = Nanoc::Int::SiteLoader.new.new_from_cwd
+    with_site do |site|
       site.compile
 
       output_file = read_output_file('datafiles', 'deep')
@@ -63,9 +53,7 @@ class DatafilesTest < MiniTest::Test
   end
 
   def test_it_applies_any_attribute
-    with_site(name: FIXTURES_DIR) do |site|
-
-      site = Nanoc::Int::SiteLoader.new.new_from_cwd
+    with_site do |site|
       site.compile
 
       output_file = read_output_file('attributes', 'attribute')
@@ -75,9 +63,7 @@ class DatafilesTest < MiniTest::Test
   end
 
   def test_it_does_not_obfuscate_content
-    with_site(name: FIXTURES_DIR) do |site|
-
-      site = Nanoc::Int::SiteLoader.new.new_from_cwd
+    with_site do |site|
       site.compile
 
       output_file = read_output_file('obfuscation', 'admonitions')
@@ -91,9 +77,7 @@ class DatafilesTest < MiniTest::Test
   end
 
   def test_it_fetches_variables
-    with_site(name: FIXTURES_DIR) do |site|
-
-      site = Nanoc::Int::SiteLoader.new.new_from_cwd
+    with_site do |site|
       site.compile
       output_file = read_output_file('datafiles', 'retrieve')
       test_file = read_test_file('datafiles', 'retrieve')
@@ -102,9 +86,7 @@ class DatafilesTest < MiniTest::Test
   end
 
   def test_it_ignores_unknown_tags
-    with_site(name: FIXTURES_DIR) do |site|
-
-      site = Nanoc::Int::SiteLoader.new.new_from_cwd
+    with_site do |site|
       site.compile
 
       output_file = read_output_file('maliciousness', 'unknown')
@@ -114,9 +96,7 @@ class DatafilesTest < MiniTest::Test
   end
 
   def test_it_works_if_an_asterisk_is_the_first_character
-    with_site(name: FIXTURES_DIR) do |site|
-
-      site = Nanoc::Int::SiteLoader.new.new_from_cwd
+    with_site do |site|
       site.compile
 
       output_file = read_output_file('maliciousness', 'asterisk_single')
@@ -126,9 +106,7 @@ class DatafilesTest < MiniTest::Test
   end
 
   def test_it_works_if_asterisks_are_the_first_two_characters
-    with_site(name: FIXTURES_DIR) do |site|
-
-      site = Nanoc::Int::SiteLoader.new.new_from_cwd
+    with_site do |site|
       site.compile
 
       output_file = read_output_file('maliciousness', 'asterisk_double')
@@ -138,9 +116,7 @@ class DatafilesTest < MiniTest::Test
   end
 
   def test_raw_tags
-    with_site(name: FIXTURES_DIR) do |site|
-
-      site = Nanoc::Int::SiteLoader.new.new_from_cwd
+    with_site do |site|
       site.compile
 
       output_file = read_output_file('liquid', 'raw')
@@ -151,9 +127,7 @@ class DatafilesTest < MiniTest::Test
   end
 
   def test_multiple_version_blocks
-    with_site(name: FIXTURES_DIR) do |site|
-
-      site = Nanoc::Int::SiteLoader.new.new_from_cwd
+    with_site do |site|
       site.compile
 
       output_file = read_output_file('liquid', 'multiple_versions')
@@ -164,9 +138,7 @@ class DatafilesTest < MiniTest::Test
   end
 
   def test_multiple_outputs
-    with_site(name: FIXTURES_DIR) do |site|
-
-      site = Nanoc::Int::SiteLoader.new.new_from_cwd
+    with_site do |site|
       site.compile
 
       single_var_github = read_output_file('multiple', 'single_var')

--- a/test/fixtures/nanoc.yaml
+++ b/test/fixtures/nanoc.yaml
@@ -1,4 +1,3 @@
-
 data_variables:
   -
     scope:

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -21,61 +21,9 @@ def read_test_file(dir, name)
   File.read(File.join(FIXTURES_DIR, 'content', dir, "#{name}.html")).gsub(/^\s*$/, '')
 end
 
-def with_site(params = {})
-  # Build site name
-  site_name = params[:name]
-  if site_name.nil?
-    @site_num ||= 0
-    site_name = "site-#{@site_num}"
-    @site_num += 1
-  end
-
-  # Build rules
-  rules_content = <<EOS
-compile '*' do
-{{compilation_rule_content}}
-end
-
-route '*' do
-if item.binary?
-  item.identifier.chop + (item[:extension] ? '.' + item[:extension] : '')
-else
-  item.identifier + 'index.html'
-end
-end
-
-layout '*', :erb
-EOS
-  rules_content.gsub!('{{compilation_rule_content}}', params[:compilation_rule_content] || '')
-
-  # Create site
-  unless File.directory?(site_name)
-    FileUtils.mkdir_p(site_name)
-    FileUtils.cd(site_name) do
-      FileUtils.mkdir_p('content')
-      FileUtils.mkdir_p('layouts')
-      FileUtils.mkdir_p('lib')
-      FileUtils.mkdir_p('output')
-
-      if params[:has_layout]
-        File.open('layouts/default.html', 'w') do |io|
-          io.write('... <%= @yield %> ...')
-        end
-      end
-
-      File.open('nanoc.yaml', 'w') do |io|
-        io << 'string_pattern_type: legacy' << "\n"
-        io << 'data_sources:' << "\n"
-        io << '  -' << "\n"
-        io << '    type: filesystem' << "\n"
-        io << '    identifier_type: legacy' << "\n"
-      end
-      File.open('Rules', 'w') { |io| io.write(rules_content) }
-    end
-  end
-
+def with_site
   # Yield site
-  FileUtils.cd(site_name) do
+  FileUtils.cd(FIXTURES_DIR) do
     yield Nanoc::Int::SiteLoader.new.new_from_cwd
   end
 end

--- a/test/variable_mixin_test.rb
+++ b/test/variable_mixin_test.rb
@@ -3,9 +3,7 @@ require 'test_helper'
 class VariablesTest < MiniTest::Test
 
   def test_it_fetches_variables
-    with_site(name: FIXTURES_DIR) do |site|
-
-      site = Nanoc::Int::SiteLoader.new.new_from_cwd
+    with_site do |site|
       site.compile
 
       assert_equal NanocConrefFS::Variables.variables[:default].keys, ['site']
@@ -14,7 +12,7 @@ class VariablesTest < MiniTest::Test
   end
 
   def test_it_fetches_datafiles
-    with_site(name: FIXTURES_DIR) do |site|
+    with_site do
       file = NanocConrefFS::Variables.fetch_data_file('reusables.intro', :default)
       assert_equal file['frontmatter_intro'], 'Here I am, in the front.'
     end


### PR DESCRIPTION
Newer versions of Nanoc broke the Conref filesystem because semver was not maintained.

This PR updates the ConrefFS system to support Nanoc 4.2+. 