### PR TITLE
Relax version requirement of dependency on Nanoc

### DIFF
--- a/nanoc-conref-fs.gemspec
+++ b/nanoc-conref-fs.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test)/})
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'nanoc', '~> 4.3.0'
+  spec.add_runtime_dependency 'nanoc', '~> 4.3'
   spec.add_runtime_dependency 'activesupport', '~> 4.2'
   spec.add_runtime_dependency 'liquid', '3.0.6'
 


### PR DESCRIPTION
The `'~> 4.3.0'` version constraint limits versions to 4.3.X, even though `nanoc-conref-fs` works with any 4.x version greater than 4.3.