### PR TITLE
Turn off Ruby warnings

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,9 +1,13 @@
+# silence ruby warnings from nanoc, liquid, etc
+$VERBOSE = nil
+
 require 'bundler/setup'
 require 'nanoc'
 require_relative '../lib/nanoc-conref-fs'
 require 'minitest/autorun'
 require 'minitest/pride'
 require 'active_support'
+
 
 FIXTURES_DIR = File.join(Dir.pwd, 'test', 'fixtures')
 CONFIG = YAML.load_file(File.join(FIXTURES_DIR, 'nanoc.yaml')).deep_symbolize_keys


### PR DESCRIPTION
Without this, you get multiple screens of warnings between each test
passing.

End of output, before:

```
vices/filter.rb:94: warning: instance variable @always_outdated not initialized
/Users/technicalpickles/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/nanoc-4.7.13/lib/nanoc/base/services/filter.rb:94: warning: instance variable @always_outdated not initialized
/Users/technicalpickles/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/nanoc-4.7.13/lib/nanoc/base/services/filter.rb:94: warning: instance variable @always_outdated not initialized
/Users/technicalpickles/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/nanoc-4.7.13/lib/nanoc/base/services/filter.rb:94: warning: instance variable @always_outdated not initialized
/Users/technicalpickles/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/nanoc-4.7.13/lib/nanoc/base/services/filter.rb:94: warning: instance variable @always_outdated not initialized
/Users/technicalpickles/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/nanoc-4.7.13/lib/nanoc/base/services/filter.rb:94: warning: instance variable @always_outdated not initialized
/Users/technicalpickles/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/nanoc-4.7.13/lib/nanoc/base/services/filter.rb:94: warning: instance variable @always_outdated not initialized
/Users/technicalpickles/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/nanoc-4.7.13/lib/nanoc/base/services/filter.rb:94: warning: instance variable @always_outdated not initialized
/Users/technicalpickles/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/nanoc-4.7.13/lib/nanoc/base/services/filter.rb:94: warning: instance variable @always_outdated not initialized
/Users/technicalpickles/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/nanoc-4.7.13/lib/nanoc/base/services/filter.rb:94: warning: instance variable @always_outdated not initialized
/Users/technicalpickles/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/nanoc-4.7.13/lib/nanoc/base/services/filter.rb:94: warning: instance variable @always_outdated not initialized
/Users/technicalpickles/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/nanoc-4.7.13/lib/nanoc/base/services/filter.rb:94: warning: instance variable @always_outdated not initialized
/Users/technicalpickles/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/nanoc-4.7.13/lib/nanoc/base/services/filter.rb:94: warning: instance variable @always_outdated not initialized
/Users/technicalpickles/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/nanoc-4.7.13/lib/nanoc/base/services/filter.rb:94: warning: instance variable @always_outdated not initialized
/Users/technicalpickles/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/nanoc-4.7.13/lib/nanoc/base/services/filter.rb:94: warning: instance variable @always_outdated not initialized
/Users/technicalpickles/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/nanoc-4.7.13/lib/nanoc/base/services/filter.rb:94: warning: instance variable @always_outdated not initialized
/Users/technicalpickles/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/nanoc-4.7.13/lib/nanoc/base/services/filter.rb:94: warning: instance variable @always_outdated not initialized
/Users/technicalpickles/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/nanoc-4.7.13/lib/nanoc/base/services/filter.rb:94: warning: instance variable @always_outdated not initialized
*

Fabulous run in 1.487633s, 18.1496 runs/s, 28.2328 assertions/s.
27 runs, 42 assertions, 0 failures, 0 errors, 0 skips
```

All of output after:

```
$ rake test
/Users/technicalpickles/.rbenv/versions/2.3.3/bin/ruby -w -I"lib:test" -I"/Users/technicalpickles/.rbe
nv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rake-12.0.0/lib" "/Users/technicalpickles/.rbenv/versions/2
.3.3/lib/ruby/gems/2.3.0/gems/rake-12.0.0/lib/rake/rake_test_loader.rb" "test/ancestry_test.rb" "test/
conref_fs_test.rb" "test/datafiles_test.rb" "test/variable_mixin_test.rb"
Run options: --seed 43182

# Running:

***************************

Fabulous run in 1.467256s, 18.4017 runs/s, 28.6249 assertions/s.

27 runs, 42 assertions, 0 failures, 0 errors, 0 skips
```