### PR TITLE
Fix custom data_dir

### DIFF
--- a/lib/nanoc-conref-fs/conref-fs.rb
+++ b/lib/nanoc-conref-fs/conref-fs.rb
@@ -10,15 +10,11 @@ class ConrefFS < Nanoc::DataSources::Filesystem
   # Before iterating over the file objects, this method loads the data folder
   # and applies it to an ivar for later usage.
   def up
-    data_files = NanocConrefFS::Datafiles.collect_data(data_dir_name)
+    data_files = NanocConrefFS::Datafiles.collect_data(ConrefFS.data_dir_name(config))
     NanocConrefFS::Variables.data_files = data_files
     NanocConrefFS::Variables.variables = {}
     reps = @config[:reps] || [:default]
     reps.each { |rep| ConrefFS.load_data_folder(@site_config, rep) }
-  end
-
-  def data_dir_name
-    config.fetch(:data_dir) { |_| 'data' }
   end
 
   def self.load_data_folder(config, rep)

--- a/lib/nanoc-conref-fs/conref-fs.rb
+++ b/lib/nanoc-conref-fs/conref-fs.rb
@@ -107,7 +107,8 @@ class ConrefFS < Nanoc::DataSources::Filesystem
     current_articles = flatten_list(current_articles).flatten
     current_articles = fix_nested_content(current_articles)
 
-    basic_yaml = NanocConrefFS::Variables.data_files["data/#{file.tr!('.', '/')}.yml"]
+    configured_data_path = 'data_jp' # TODO: Placeholder
+    basic_yaml = NanocConrefFS::Variables.data_files["#{configured_data_path}/#{file.tr!('.', '/')}.yml"]
     basic_yaml.gsub!(/\{%.+/, '')
     full_file = YAML.load(basic_yaml)
 

--- a/lib/nanoc-conref-fs/conref-fs.rb
+++ b/lib/nanoc-conref-fs/conref-fs.rb
@@ -1,4 +1,5 @@
 require_relative 'conrefifier'
+require 'active_support/core_ext/hash'
 require 'active_support/core_ext/string'
 
 class ConrefFS < Nanoc::DataSources::Filesystem
@@ -115,6 +116,7 @@ class ConrefFS < Nanoc::DataSources::Filesystem
   # - Default `data_dir` of 'data' if none is configured in `nanoc.yaml`
   def self.data_dir_name(config=nil)
     config ||= YAML.load_file('nanoc.yaml')
+    config = config.to_h.with_indifferent_access()
 
     # In certain parts of the nanoc pipeline the config is rooted at the
     # data-source already.
@@ -122,14 +124,11 @@ class ConrefFS < Nanoc::DataSources::Filesystem
     return data_dir if data_dir
 
     data_sources = config.fetch("data_sources") { nil }
-    data_sources = config.fetch(:data_sources) { nil } unless data_sources
     return DEFAULT_DATA_DIR unless data_sources
 
     data_source = data_sources.find { |ds| ds["type"] == "conref-fs" }
-    data_source = data_sources.find { |ds| ds[:type] == "conref-fs" } unless data_source
 
     data_dir = data_source.fetch("data_dir") { nil }
-    data_dir = data_source.fetch(:data_dir) unless data_dir
     return DEFAULT_DATA_DIR unless data_dir
     return data_dir
   end

--- a/lib/nanoc-conref-fs/conref-fs.rb
+++ b/lib/nanoc-conref-fs/conref-fs.rb
@@ -2,6 +2,8 @@ require_relative 'conrefifier'
 require 'active_support/core_ext/string'
 
 class ConrefFS < Nanoc::DataSources::Filesystem
+  DEFAULT_DATA_DIR = "data".freeze
+
   include NanocConrefFS::Variables
   include NanocConrefFS::Ancestry
 
@@ -113,9 +115,13 @@ class ConrefFS < Nanoc::DataSources::Filesystem
   # - Default `data_dir` of 'data' if none is configured in `nanoc.yaml`
   def self.data_dir_name(config=nil)
     config ||= YAML.load_file('nanoc.yaml')
-    data_sources = config.fetch("data_sources") { [] }
-    data_source = data_sources.find { |ds| ds["type"] == "conref-fs" } || { "data_dir": "data" }
-    return data_source["data_dir"] || "data"
+    data_sources = config.fetch("data_sources") { nil }
+    return DEFAULT_DATA_DIR unless data_sources
+
+    data_source = data_sources.find { |ds| ds["type"] == "conref-fs" }
+    return DEFAULT_DATA_DIR unless data_source && data_source.has_key?("data_dir")
+
+    return data_source["data_dir"]
   end
 
   def self.create_ignore_rules(rep, file)

--- a/lib/nanoc-conref-fs/conref-fs.rb
+++ b/lib/nanoc-conref-fs/conref-fs.rb
@@ -120,7 +120,7 @@ class ConrefFS < Nanoc::DataSources::Filesystem
 
     # In certain parts of the nanoc pipeline the config is rooted at the
     # data-source already.
-    data_dir = config.fetch(:data_dir) { nil }
+    data_dir = config.fetch("data_dir") { nil }
     return data_dir if data_dir
 
     data_sources = config.fetch("data_sources") { nil }

--- a/lib/nanoc-conref-fs/datafiles.rb
+++ b/lib/nanoc-conref-fs/datafiles.rb
@@ -19,10 +19,8 @@ module NanocConrefFS
         raise "#{e.message}: #{e.inspect}"
       end
 
-      configured_data_path = config[:data_sources][0][:data_dir]
-
       path = path.dup
-      path.slice!("#{configured_data_path}/") # Beware the slashes, they are important for tokenization
+      path.slice!("#{ConrefFS.data_dir_name(config)}/") # Beware the slashes, they are important for tokenization
       path.sub!(/\.[yaml]{3,4}\z/, '')
       data_keys = path.split('/')
 

--- a/lib/nanoc-conref-fs/datafiles.rb
+++ b/lib/nanoc-conref-fs/datafiles.rb
@@ -19,8 +19,10 @@ module NanocConrefFS
         raise "#{e.message}: #{e.inspect}"
       end
 
+      configured_data_path = config[:data_sources][0][:data_dir]
+
       path = path.dup
-      path.slice!('data/')
+      path.slice!("#{configured_data_path}/") # Beware the slashes, they are important for tokenization
       path.sub!(/\.[yaml]{3,4}\z/, '')
       data_keys = path.split('/')
 

--- a/lib/nanoc-conref-fs/variables.rb
+++ b/lib/nanoc-conref-fs/variables.rb
@@ -20,9 +20,13 @@ module NanocConrefFS
     def self.fetch_data_file(association, rep)
       return nil unless association
       reference = association.split('.')
-      data = @variables[rep]['site']['data']
+      data = @variables[rep]['site'][ConrefFS.data_dir_name]
       while key = reference.shift
-        data = data[key]
+        begin
+          data = data[key]
+        rescue Exception => ex
+          raise "Unable to locate #{key} in #{@variables[rep]['site'].inspect}"
+        end
       end
       data
     end

--- a/nanoc-conref-fs.gemspec
+++ b/nanoc-conref-fs.gemspec
@@ -3,7 +3,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = 'nanoc-conref-fs'
-  spec.version       = '0.6.9'
+  spec.version       = '0.6.10'
   spec.authors       = ['Garen Torikian']
   spec.email         = ['gjtorikian@gmail.com']
   spec.summary       = 'A Nanoc filesystem to permit using conrefs/reusables in your content.'

--- a/test/datafiles_test.rb
+++ b/test/datafiles_test.rb
@@ -45,4 +45,12 @@ class DatafilesTest < MiniTest::Test
     assert_includes result.to_s, 'About gists'
     refute_includes result.to_s, 'Deleting an anonymous gist'
   end
+
+  def test_it_can_use_a_custom_datafile
+    file = File.join(FIXTURES_DIR, 'data_custom', 'categories', 'custom.yml')
+    content = File.read(file)
+    config = YAML.load_file(File.join(FIXTURES_DIR, 'nanoc.custom_data_dir.yaml')).deep_symbolize_keys
+    result = NanocConrefFS::Datafiles.apply_conditionals(config, path: file, content: content, rep: :default)
+    assert_includes result.to_s, 'How to Use a Custom Data Directory'
+  end
 end

--- a/test/fixtures/data_custom/categories/custom.yml
+++ b/test/fixtures/data_custom/categories/custom.yml
@@ -1,0 +1,4 @@
+{% if page.version != 'cloud' %}
+Custom Files:
+  - How to Use a Custom Data Directory
+{% endif %}

--- a/test/fixtures/nanoc.custom_data_dir.yaml
+++ b/test/fixtures/nanoc.custom_data_dir.yaml
@@ -1,0 +1,87 @@
+data_variables:
+  -
+    scope:
+      path: ""
+    values:
+      version: "dotcom"
+  -
+    scope:
+      path: ""
+      reps:
+        - :X
+    values:
+      version: "X"
+
+page_variables:
+  -
+    scope:
+      path: ""
+    values:
+      version: "dotcom"
+      data_association: "categories.category"
+      just_a_key: wow!
+  -
+    scope:
+      path: "array_parents"
+    values:
+      version: "dotcom"
+      data_association: "categories.simple"
+  -
+    scope:
+      path: "array_children"
+    values:
+      version: "dotcom"
+      data_association: "categories.simple"
+  -
+    scope:
+      path: "different"
+    values:
+      version: "2.0"
+  -
+    scope:
+      path: "empty-categories"
+    values:
+      version: "dotcom"
+      data_association: "categories.empty_category"
+      just_a_key: wow!
+  -
+    scope:
+      path: "multiple_versions"
+    values:
+      version: 2.2
+
+string_pattern_type: glob
+
+text_extensions: [ 'coffee', 'css', 'erb', 'haml', 'handlebars', 'hb', 'htm', 'html', 'js', 'less', 'markdown', 'md', 'ms', 'mustache', 'php', 'rb', 'rdoc', 'sass', 'scss', 'slim', 'txt', 'xhtml', 'xml' ]
+
+output_dir: output
+
+index_filenames: [ 'index.html' ]
+
+enable_output_diff: false
+
+prune:
+  auto_prune: true
+
+  exclude: [ '.git', '.hg', '.svn', 'CVS' ]
+
+data_sources:
+  -
+    # The type is the identifier of the data source.
+    type: conref-fs
+
+    data_dir: 'data_custom/'
+
+    items_root: /
+    layouts_root: /
+
+    encoding: utf-8
+
+    identifier_type: full
+    reps:
+      - :default
+      - :X
+
+checks:
+  internal_links:
+    exclude: []


### PR DESCRIPTION
This PR fixes the previous implementation for custom `data_dir` support.

- Converts hard-coded "data" paths to dynamic references to `ConrefFS.data_dir_name`
- Adds `ConrefFS.data_dir_name` so that it can be called at any point in the Nanoc pipeline (such as in the Rules file).
- Fixes incorrect key lookup in previous implementation

